### PR TITLE
Export node_is_isolated()

### DIFF
--- a/R/node.R
+++ b/R/node.R
@@ -79,6 +79,7 @@ node_is_source <- function() {
 }
 #' @describeIn node_types is the node unconnected
 #' @importFrom igraph degree
+#' @export
 node_is_isolated <- function() {
   expect_nodes()
   graph <- .G()


### PR DESCRIPTION
The function node_is_isolated() was not exported. Now it is via @export.