### PR TITLE
Fix example in graph_types doc

### DIFF
--- a/R/graph_types.R
+++ b/R/graph_types.R
@@ -19,7 +19,7 @@
 #' @examples
 #' gr <- create_tree(50, 4)
 #'
-#' with_graph(gr, graph_is_tree)
+#' with_graph(gr, graph_is_tree())
 #'
 NULL
 

--- a/man/graph_types.Rd
+++ b/man/graph_types.Rd
@@ -81,6 +81,6 @@ properties and will all return a logical scalar.
 \examples{
 gr <- create_tree(50, 4)
 
-with_graph(gr, graph_is_tree)
+with_graph(gr, graph_is_tree())
 
 }


### PR DESCRIPTION
The current example in `tidygraph/R/graph_types.R` doesn't return a logical scalar:

```R
library(tidygraph)
gr <- create_tree(50, 4)
with_graph(gr, graph_is_tree)
#> function () 
#> {
#>     is_tree(.G())
#> }
#> <environment: namespace:tidygraph>
```

I think `graph_is_tree` should be `graph_is_tree()`. I added the parenthess and run `devtools::document` in this commit.