### PR TITLE
Handling an adjacency matrix from a data.frame

### DIFF
--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -28,7 +28,10 @@ as_graph_set_df <- function(x, simple = TRUE) {
   if (simple) {
     x <- as.matrix(x)
     mode(x) <- 'integer'
-    adj_mat <- x %*% t(x)
+    adj_mat <- x
+    if (nrow(x) != ncol(x)) {
+      adj_mat <- x %*% t(x)
+    }
     if (!is.null(attr(x, 'row.names'))) {
       colnames(adj_mat) <- rownames(adj_mat) <- row.names(x)
     }


### PR DESCRIPTION
Suggestion to allow passing an adjacency matrix as a `data.frame`.

This may not be an appropriate solution however I noticed that by passing a `data.frame` that is already a simple graph adjacency matrix (it is `1` or `0` only and square), `guess_df_type` picks it up as a set membership table and multiplies itself with its transpose.

Would it be fair to say that if the df is square it is assumed to be an adjacency matrix already? If so, I've just made the transpose multiplication conditional on not being square.

Current workaround is

```r
mat <- as.matrix(df)
dimnames(mat) <- purrr::rerun(2, seq_len(nrow(df)) %>% as.character)
igraph::graph_from_adjacency_matrix(mat)
```
which seems like a duplication of `as_graph_set_df`