### PR TITLE
Update list.R

### DIFF
--- a/R/list.R
+++ b/R/list.R
@@ -74,11 +74,11 @@ as_graph_node_edge <- function(x, directed) {
   name_ind <- which(names(nodes) == 'name')
   if (length(name_ind) == 0) name_ind <- 1
   edges <- edges[, c(from_ind, to_ind, seq_along(edges)[-c(from_ind, to_ind)]), drop = FALSE]
-  if (is.character(edges[, 1])) {
-    edges[, 1] <- match(edges[, 1], nodes[, name_ind])
+  if (is.character(edges[[1]])) {
+    edges[, 1] <- match(edges[[1]], nodes[[name_ind]])
   }
-  if (is.character(edges[, 2])) {
-    edges[, 2] <- match(edges[, 2], nodes[, name_ind])
+  if (is.character(edges[[2]])) {
+    edges[, 2] <- match(edges[[2]], nodes[[name_ind]])
   }
   gr <- graph_from_edgelist(as.matrix(edges[, 1:2]), directed = directed)
   edge_attr(gr) <- as.list(edges[, -c(1:2), drop = FALSE])


### PR DESCRIPTION
Revised lines 77-82, replacing single bracket notation to double bracket notation for subsetting columns to accomdate both `tibble` and `data.frame` objects. The evaluation `is.character(edges[, 1])` for a tibble evaluates the `tibble` object and not the column. I revised this to `is.character(edges[[1]])`, which evaluates the column. This works for `data.frame` and `tibble` objects. Each case of single bracket notation was replaced with double bracket notation.