### PR TITLE
add pillar subtle printing to print headers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1.9000
 Roxygen: list(markdown = TRUE)
-Imports: tibble,
+Imports: 
+    tibble,
     dplyr (>= 0.7),
     igraph,
     magrittr,
@@ -29,7 +30,8 @@ Imports: tibble,
     Rcpp,
     tools,
     stats,
-    tidyr
+    tidyr,
+    pillar
 URL: https://github.com/thomasp85/tidygraph
 BugReports: https://github.com/thomasp85/tidygraph/issues
 LinkingTo: Rcpp

--- a/R/tbl_graph.R
+++ b/R/tbl_graph.R
@@ -63,6 +63,7 @@ is.tbl_graph <- function(x) {
 #' @importFrom tibble trunc_mat
 #' @importFrom tools toTitleCase
 #' @importFrom rlang as_quosure sym
+#' @importFrom pillar style_subtle
 #' @export
 print.tbl_graph <- function(x, ...) {
   arg_list <- list(...)
@@ -73,12 +74,13 @@ print.tbl_graph <- function(x, ...) {
   names(top$summary)[1] <- toTitleCase(paste0(substr(active(x), 1, 4), ' data'))
   bottom <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x, active = not_active), n = 3)))
   names(bottom$summary)[1] <- toTitleCase(paste0(substr(not_active, 1, 4), ' data'))
-  cat('# A tbl_graph: ', gorder(x), ' nodes and ', gsize(x), ' edges\n', sep = '')
-  cat('#\n')
-  cat('# ', graph_desc, '\n', sep = '')
-  cat('#\n')
+  cat_subtle <- function(...) cat(style_subtle(paste(...)))
+  cat_subtle('# A tbl_graph: ', gorder(x), ' nodes and ', gsize(x), ' edges\n', sep = '')
+  cat_subtle('#\n')
+  cat_subtle('# ', graph_desc, '\n', sep = '')
+  cat_subtle('#\n')
   print(top)
-  cat('#\n')
+  cat_subtle('#\n')
   print(bottom)
   invisible(x)
 }

--- a/R/tbl_graph.R
+++ b/R/tbl_graph.R
@@ -74,7 +74,7 @@ print.tbl_graph <- function(x, ...) {
   names(top$summary)[1] <- toTitleCase(paste0(substr(active(x), 1, 4), ' data'))
   bottom <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x, active = not_active), n = 3)))
   names(bottom$summary)[1] <- toTitleCase(paste0(substr(not_active, 1, 4), ' data'))
-  cat_subtle <- function(...) cat(style_subtle(paste(...)))
+  cat_subtle <- function(...) cat(pillar::style_subtle(paste(...)))
   cat_subtle('# A tbl_graph: ', gorder(x), ' nodes and ', gsize(x), ' edges\n', sep = '')
   cat_subtle('#\n')
   cat_subtle('# ', graph_desc, '\n', sep = '')

--- a/R/tbl_graph.R
+++ b/R/tbl_graph.R
@@ -74,7 +74,6 @@ print.tbl_graph <- function(x, ...) {
   names(top$summary)[1] <- toTitleCase(paste0(substr(active(x), 1, 4), ' data'))
   bottom <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x, active = not_active), n = 3)))
   names(bottom$summary)[1] <- toTitleCase(paste0(substr(not_active, 1, 4), ' data'))
-  cat_subtle <- function(...) cat(pillar::style_subtle(paste(...)))
   cat_subtle('# A tbl_graph: ', gorder(x), ' nodes and ', gsize(x), ' edges\n', sep = '')
   cat_subtle('#\n')
   cat_subtle('# ', graph_desc, '\n', sep = '')
@@ -84,6 +83,9 @@ print.tbl_graph <- function(x, ...) {
   print(bottom)
   invisible(x)
 }
+
+cat_subtle <- function(...) cat(pillar::style_subtle(paste0(...)))
+
 #' @export
 print.morphed_tbl_graph <- function(x, ...) {
   graph <- attr(x, '.orig_graph')


### PR DESCRIPTION
This may be a little ahead of the game in terms of where tibble/pillar are in development for their next releases (not sure how finalized these things are), but I noticed that the colored printing of tibbles have the headers in grey, while print.tbl_graph uses the normal printing colors. This PR changes the headers for it to `pillar::style_subtle()` so that they are consistent. Of course, that assumes you want them to be!