### PR TITLE
Bump version and date past CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: tidygraph
 Type: Package
 Title: A Tidy API for Graph Manipulation
-Version: 1.0.0.9999
-Date: 2017-12-12
+Version: 1.1.0.9999
+Date: 2018-02-10
 Authors@R:
     person(given = "Thomas Lin",
            family = "Pedersen",


### PR DESCRIPTION
GitHub dev version is currently behind latest CRAN version which throws off package manages (eg. packrat)

Fixes #62