### PR TITLE
Replacement network_to_igraph conversion function.

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -17,7 +17,7 @@ as_tbl_graph.network <- function(x, ...) {
 #' as an igraph object.
 #'
 #' @importFrom dplyr bind_rows
-#' @importFrom igraph graph.empty graph_attr<- edge_attr<- vertex_attr<-
+#' @importFrom igraph graph_attr<- edge_attr<- vertex_attr<-
 #' @noRd
 #'
 network_to_igraph <- function(graph) {
@@ -95,7 +95,7 @@ network_to_igraph <- function(graph) {
   # vectorizing edges allows them to be added to an empty graph
   el_vec <- as.vector(t(el))
   # starting with an empty graph allows for isolates
-  new_graph <- graph.empty(graph$gal$n, directed = graph$gal$directed)
+  new_graph <- igraph::graph.empty(graph$gal$n, directed = graph$gal$directed)
   new_graph <- add_edges(new_graph, edges = el_vec)
   if (length(graph_attrs)) {
     graph_attr(new_graph) <- graph_attrs

--- a/R/network.R
+++ b/R/network.R
@@ -17,12 +17,11 @@ as_tbl_graph.network <- function(x, ...) {
 #' as an igraph object.
 #'
 #' @importFrom dplyr bind_rows
-#' @importFrom igraph graph_attr<- edge_attr<- vertex_attr<-
+#' @importFrom igraph add_edges graph_attr<- edge_attr<- vertex_attr<-
 #' @noRd
 #'
 network_to_igraph <- function(graph) {
   metadata <- graph$gal
-  # graph-level "attributes" to drop as they're better described as metadata
   metadata_names <- c("n", "directed", "hyper", "loops", "multiple", "bipartite", "mnext")
   graph_attrs <- metadata[!names(metadata) %in% metadata_names]
   if (metadata$hyper) {
@@ -30,40 +29,13 @@ network_to_igraph <- function(graph) {
   }
   
   node_attrs <- bind_rows(lapply(graph$val, `[`))
-  # {igraph} doesn't track "missing"/"na" vertices.
   node_attrs <- node_attrs[colnames(node_attrs) != "na"]
-  # {network} assumes vertex names are assigned to an attribute called "vertex.names"
-  # {igraph} assumes they are assigned to an attribute called "name"
   names(node_attrs)[names(node_attrs) == "vertex.names"] <- "name"
-  # both packages have instances where they expect vertex names to be their first attribute
   node_attrs <- node_attrs[, c("name", names(node_attrs)[names(node_attrs) != "name"])]
   
-  # "bipartite" networks are the weak spot:
-  #
-  # Both packages are problematic in conflating bipartite and two-mode networks, but do
-  # so in different ways. They are also both insufficiently strict about handling graphs 
-  # that are inherently not bipartite (e.g. they allow bipartite networks to have loops).
-  #
-  # {network} tracks the number of vertices belonging to the "actors" mode as a graph-level 
-  # attribute: `<network-object>$gal$bipartite`.
-  # 
-  # The count of vertices of the "non-actors" mode (e.g events, locations, etc.) are then 
-  # `<network-object>$gal$n - <network-object>$gal$bipartite`.
-  # 
-  # If `<network-object>$gal$bipartite` is numeric, it's considered "bipartite".
-  # If it's `FALSE` OR `NULL`, it's not. 
-  #
-  # This is in conflict with {igraph}, which explicitly uses a `logical` vertex attribute
-  # to track vertex modes, conventionally named "type".
-  # 
-  # The solution I've implemented in my own package is to assign "actors" (vertices with 
-  # IDs < `<network-object>$gal$bipartite`) as `TRUE`.
-  # This simplifies things when converting back to network-class objects as the "type"
-  # attribute can then be interpreted as "is_actor". This facilitates consistently accurate
-  # round-trip conversions.
   if (is.numeric(metadata$bipartite)) {
     if ("type" %in% names(node_attrs)) {
-      if(is.logical(node_attrs$type)) {
+      if (is.logical(node_attrs$type)) {
         warning('This network object is bipartite and uses a `logical` vertex attribute
                  named "type". igraph will assume that "type" is intended to label vertex 
                  modes in the resulting graph. Rename this vertex attribute if this is not 
@@ -80,22 +52,18 @@ network_to_igraph <- function(graph) {
   }
   
   edge_attrs <- bind_rows(lapply(graph$mel, `[[`, "atl"))
-  # {igraph} doesn't track "missing"/"na" edges.
   edge_attrs <- edge_attrs[colnames(edge_attrs) != "na"]
   
-  outl <- vapply(graph$mel, `[[`, numeric(1), "outl") # may be integer or double
+  outl <- vapply(graph$mel, `[[`, numeric(1), "outl")
   inl <- vapply(graph$mel, `[[`, numeric(1), "inl")
   if (metadata$directed) {
     el <- cbind(outl, inl)
   } else {
-    # {network} reverses egos and alters for undirected edge lists. Controling this allows
-    # validation of round-trip conversions.
     el <- cbind(inl, outl)
   }
-  # vectorizing edges allows them to be added to an empty graph
   el_vec <- as.vector(t(el))
-  # starting with an empty graph allows for isolates
-  new_graph <- igraph::graph.empty(graph$gal$n, directed = graph$gal$directed)
+
+  new_graph <- igraph::graph.empty(graph$gal$n, directed = isTRUE(graph$gal$directed))
   new_graph <- add_edges(new_graph, edges = el_vec)
   if (length(graph_attrs)) {
     graph_attr(new_graph) <- graph_attrs

--- a/R/network.R
+++ b/R/network.R
@@ -30,7 +30,7 @@ network_to_igraph <- function(graph) {
     stop('Hypergraphs are currently unsupported', call. = FALSE)
   }
   
-  node_attrs <- dplyr::bind_rows(lapply(graph$val, `[`))
+  node_attrs <- bind_rows(lapply(graph$val, `[`))
   # {igraph} doesn't track "missing"/"na" vertices.
   node_attrs <- node_attrs[colnames(node_attrs) != "na"]
   # {network} assumes vertex names are assigned to an attribute called "vertex.names"
@@ -80,7 +80,7 @@ network_to_igraph <- function(graph) {
                          rep(FALSE, metadata$n - metadata$bipartite))
   }
   
-  edge_attrs <- dplyr::bind_rows(lapply(graph$mel, `[[`, "atl"))
+  edge_attrs <- bind_rows(lapply(graph$mel, `[[`, "atl"))
   # {igraph} doesn't track "missing"/"na" edges.
   edge_attrs <- edge_attrs[colnames(edge_attrs) != "na"]
   
@@ -96,16 +96,16 @@ network_to_igraph <- function(graph) {
   # vectorizing edges allows them to be added to an empty graph
   el_vec <- as.vector(t(el))
   # starting with an empty graph allows for isolates
-  new_graph <- igraph::graph.empty(graph$gal$n, directed = graph$gal$directed)
-  new_graph <- igraph::add_edges(new_graph, edges = el_vec)
+  new_graph <- graph.empty(graph$gal$n, directed = graph$gal$directed)
+  new_graph <- add_edges(new_graph, edges = el_vec)
   if (length(graph_attrs)) {
-    igraph::graph_attr(new_graph) <- graph_attrs
+    graph_attr(new_graph) <- graph_attrs
     }
   if (nrow(node_attrs)) {
-    igraph::vertex_attr(new_graph) <- node_attrs
+    vertex_attr(new_graph) <- node_attrs
     }
   if (nrow(edge_attrs)) {
-    igraph::edge_attr(new_graph) <- edge_attrs
+    edge_attr(new_graph) <- edge_attrs
     }
   
   new_graph

--- a/R/network.R
+++ b/R/network.R
@@ -69,7 +69,7 @@ network_to_igraph <- function(graph) {
                  modes in the resulting graph. Rename this vertex attribute if this is not 
                  intentional.')
         }
-      if(!is.logical(node_attrs$type)) {
+      if (!is.logical(node_attrs$type)) {
         stop('This network object is bipartite, but uses a non-`logical` vertex attribute 
               named "type". igraph uses a `logical` vertex attribute named "type" for 
               bipartite mapping. Rename this vertex attribute.', call. = FALSE)
@@ -99,13 +99,13 @@ network_to_igraph <- function(graph) {
   new_graph <- add_edges(new_graph, edges = el_vec)
   if (length(graph_attrs)) {
     graph_attr(new_graph) <- graph_attrs
-    }
+  }
   if (nrow(node_attrs)) {
     vertex_attr(new_graph) <- node_attrs
-    }
+  }
   if (nrow(edge_attrs)) {
     edge_attr(new_graph) <- edge_attrs
-    }
+  }
   
   new_graph
 }

--- a/R/network.R
+++ b/R/network.R
@@ -17,8 +17,7 @@ as_tbl_graph.network <- function(x, ...) {
 #' as an igraph object.
 #'
 #' @importFrom dplyr bind_rows
-#' @importFrom igraph graph_attr<- graph.empty edge_attr<- vertex_attr<-
-#' @importFrom utils modifyList
+#' @importFrom igraph graph.empty graph_attr<- edge_attr<- vertex_attr<-
 #' @noRd
 #'
 network_to_igraph <- function(graph) {

--- a/tests/testthat/test-network_to_igraph.R
+++ b/tests/testthat/test-network_to_igraph.R
@@ -1,0 +1,109 @@
+context("network_to_igraph")
+
+build_test_graph <- function(ig_or_nw, bipartite = FALSE, seed = 1234) {
+  n_nodes = 30L
+  n_edges = 500L
+  set.seed(seed)
+  graph_attrs <- list(graph_chr = "Much Graph. Many Attributes",
+                      graph_lgl = TRUE,
+                      graph_int = 1L,
+                      graph_dbl = 3.14)
+  vertices_df <- data.frame(vertex.names = paste0("node_", seq_len(n_nodes)),
+                            node_chr = sample(letters, n_nodes, replace = TRUE),
+                            node_int = sample(seq.int(100L), n_nodes),
+                            node_dbl = runif(n_nodes, 0, 100),
+                            node_lgl = sample(c(TRUE, FALSE), n_nodes, replace = TRUE),
+                            stringsAsFactors = FALSE)
+  edges_df <- data.frame(from = sample(seq_len(n_nodes), n_edges, replace = TRUE),
+                         to = sample(seq_len(n_nodes), n_edges, replace = TRUE),
+                         edge_chr = sample(letters, n_edges, replace = TRUE),
+                         edge_int = sample(seq.int(1000L), n_edges, replace = FALSE),
+                         edge_dbl = runif(n_edges, 0, 1000),
+                         edge_lgl = sample(c(TRUE, FALSE), n_edges, replace = TRUE),
+                         stringsAsFactors = FALSE)
+  if(!bipartite) {
+    if(ig_or_nw == "ig") {
+      names(vertices_df)[names(vertices_df) == "vertex.names"] <- "name"
+      edges_df$from <- vertices_df$name[edges_df$from]
+      edges_df$to <- vertices_df$name[edges_df$to]
+      out <- igraph::graph_from_data_frame(edges_df, vertices = vertices_df)
+      igraph::graph_attr(out) <- graph_attrs
+      return(out)
+    }
+    if(ig_or_nw == "nw") {
+      el <- as.matrix(edges_df[, c("from", "to")])
+      out <- network::as.network.matrix(el, matrix.type = "edgelist", loops = TRUE,
+                                        multiple = TRUE)
+      for(g in names(graph_attrs)) {
+        network::set.network.attribute(out, g, graph_attrs[[g]])
+      }
+      for(v in names(vertices_df)) {
+        network::set.vertex.attribute(out, v, vertices_df[[v]])
+      }
+      for(e in names(edges_df)[!names(edges_df) %in% c("from", "to")]) {
+        network::set.edge.attribute(out, e, edges_df[[e]])
+      }
+      return(out)
+    }
+  }
+  set.seed(seed)
+  affil_matrix <- matrix(rbinom((n_nodes / 2)^2, size = 1, prob = 0.5), nrow = n_nodes / 2,
+                         dimnames = list(paste0("act_node_", seq_len(n_nodes / 2)),
+                                         paste0("non_act_node_", seq_len(n_nodes / 2))))
+  n_edges <- sum(affil_matrix)
+  edges_df <- edges_df[seq_len(n_edges), 3:ncol(edges_df)]
+  if(ig_or_nw == "ig") {
+    names(vertices_df)[names(vertices_df) == "vertex.names"] <- "name"
+    out <- igraph::graph_from_incidence_matrix(affil_matrix, directed = FALSE) 
+    igraph::graph_attr(out) <- graph_attrs
+    igraph::edge_attr(out) <- edges_df
+    igraph::vertex_attr(out) <- vertices_df
+    igraph::V(out)$type <- !igraph::bipartite.mapping(out)$type
+   return(out)
+  }
+  if(ig_or_nw == "nw") {
+    out <- network::as.network.matrix(affil_matrix, bipartite = TRUE)
+    for(g in names(graph_attrs)) {
+      network::set.network.attribute(out, g, graph_attrs[[g]])
+    }
+    for(v in names(vertices_df)) {
+      network::set.vertex.attribute(out, v, vertices_df[[v]])
+    }
+    for(e in names(edges_df)[!names(edges_df) %in% c("from", "to")]) {
+      network::set.edge.attribute(out, e, edges_df[[e]])
+    }
+    return(out)
+  }
+}
+
+are_same_igraphs <- function(x, y) {
+  get_node_attrs <- function(ig) {
+    v <- igraph::as_data_frame(ig, what = "vertices")
+    v[sort(names(v))]
+  }
+  get_edge_attrs <- function(ig) {
+    e <- igraph::as_data_frame(ig)
+    e[sort(names(e))]
+  }
+  get_graph_attrs <- function(ig) {
+    g <- igraph::graph_attr(ig)
+    as.data.frame(g[sort(names(g))])
+  }
+  all(get_node_attrs(x) == get_node_attrs(y),
+      get_edge_attrs(x) == get_edge_attrs(y),
+      get_graph_attrs(x) == get_graph_attrs(y))
+}
+
+test_that("unipartite network objects convert correctly", {
+  expect_true(
+    are_same_igraphs(network_to_igraph(build_test_graph("nw")),
+                     build_test_graph("ig"))
+    )
+  })
+
+test_that("bipartite network objects convert correctly", {
+  expect_true(
+    are_same_igraphs(network_to_igraph(build_test_graph("nw", bipartite = TRUE)),
+                     build_test_graph("ig", bipartite = TRUE))
+    )
+  })


### PR DESCRIPTION
This should do the trick for conversions from network objects. Actively avoiding `network` attribute queries works better as it skips some legacy issues and name sorting.

The comments are intentionally verbose for the moment as I wanted to clarify some of the compatibility issues I worked around. `build_test_graph()` attempts to make a graph as complicated as possible without it being a computational burden, but the test can be dropped if you'd prefer.

Let me know if it suits you or what you'd like to see changed.