### PR TITLE
Compatibility with dev version of tibble

### DIFF
--- a/R/tibble.R
+++ b/R/tibble.R
@@ -46,7 +46,7 @@ edge_tibble <- function(x) {
   }
   e_list <- as_edgelist(x, names = FALSE)
   mode(e_list) <- 'integer'
+  colnames(e_list) <- c('from', 'to')
   e_list <- as_tibble(e_list)
-  names(e_list) <- c('from', 'to')
   bind_cols(e_list, tbl)
 }


### PR DESCRIPTION
Only need to assign column names before calling `as_tibble()`, instead of after.

CC @jennybc.