### PR TITLE
Allow user-specified `n` to print statement

### DIFF
--- a/R/tbl_graph.R
+++ b/R/tbl_graph.R
@@ -75,10 +75,10 @@ print.tbl_graph <- function(x, ...) {
   arg_list <- list(...)
   graph_desc <- describe_graph(x)
   not_active <- if (active(x) == 'nodes') 'edges' else 'nodes'
-  top <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x), n = 6)))
+  top <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x))))
   top$summary[1] <- paste0(top$summary[1], ' (active)')
   names(top$summary)[1] <- toTitleCase(paste0(substr(active(x), 1, 4), ' data'))
-  bottom <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x, active = not_active), n = 3)))
+  bottom <- do.call(trunc_mat, modifyList(arg_list, list(x = as_tibble(x, active = not_active))))
   names(bottom$summary)[1] <- toTitleCase(paste0(substr(not_active, 1, 4), ' data'))
   cat_subtle('# A tbl_graph: ', gorder(x), ' nodes and ', gsize(x), ' edges\n', sep = '')
   cat_subtle('#\n')


### PR DESCRIPTION
The existing code forced printing of 6 rows of the active/top layer, and 3 rows of the inactive/bottom layer of the tbl_graph in a way which did not allow specification of `n` to the print method. I considered a few different options for ways to allow users to specify n that was most in line with the tidyverse philosophy to print a limited number of rows. This commit does the simplest thing, which is to remove the defaults of 6 and 3. The result of this is a modified default of 10 for each, derived from tibble.

Certainly other options. I'd be happy to work on another approach if you want to keep the *total* of 9 rows printed instead, for example tidygraph could always print 2/3 of `n` for top, 1/3 for bottom, or accept a parameter for each.