### PR TITLE
Argument neimode is deprecated; using mode instead

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -424,7 +424,7 @@ map_local_dbl <- function(order = 1, mode = 'all', mindist = 0, .f, ...) {
 #' @importFrom igraph bfs
 #' @importFrom tibble tibble
 bfs_df <- function(graph, root, mode, unreachable) {
-  search <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  search <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
                 order = TRUE, rank = TRUE, father = TRUE, pred = TRUE,
                 succ = TRUE, dist = TRUE)
   nodes <- seq_along(search$order)
@@ -441,7 +441,7 @@ bfs_df <- function(graph, root, mode, unreachable) {
 #' @importFrom igraph dfs
 #' @importFrom tibble tibble
 dfs_df <- function(graph, root, mode, unreachable) {
-  search <- dfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  search <- dfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
                 order = TRUE, order.out = TRUE, father = TRUE, dist = TRUE)
   nodes <- seq_along(search$order)
   tibble(

--- a/R/morphers.R
+++ b/R/morphers.R
@@ -199,7 +199,7 @@ to_shortest_path <- function(graph, from, to, mode = 'out', weights = NULL) {
 to_bfs_tree <- function(graph, root, mode = 'out', unreachable = FALSE) {
   root <- eval_tidy(enquo(root), as_tibble(graph, 'nodes'))
   root <- as_ind(root, gorder(graph))
-  search <- bfs(graph, root, neimode = mode, unreachable = unreachable, father = TRUE)
+  search <- bfs(graph, root, mode = mode, unreachable = unreachable, father = TRUE)
   bfs_graph <- search_to_graph(graph, search)
   list(
     bfs = bfs_graph
@@ -212,7 +212,7 @@ to_bfs_tree <- function(graph, root, mode = 'out', unreachable = FALSE) {
 to_dfs_tree <- function(graph, root, mode = 'out', unreachable = FALSE) {
   root <- eval_tidy(enquo(root), as_tibble(graph, 'nodes'))
   root <- as_ind(root, gorder(graph))
-  search <- dfs(graph, root, neimode = mode, unreachable = unreachable, father = TRUE)
+  search <- dfs(graph, root, mode = mode, unreachable = unreachable, father = TRUE)
   dfs_graph <- search_to_graph(graph, search)
   list(
     dfs = dfs_graph

--- a/R/search.R
+++ b/R/search.R
@@ -44,7 +44,7 @@ bfs_rank <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, rank = TRUE)$rank
   as.integer(ind)
 }
@@ -55,7 +55,7 @@ bfs_parent <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
       order = TRUE, father = TRUE)$father
   as.integer(ind)
 }
@@ -66,7 +66,7 @@ bfs_before <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, pred = TRUE)$pred
   as.integer(ind)
 }
@@ -77,7 +77,7 @@ bfs_after <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, succ = TRUE)$succ
   as.integer(ind)
 }
@@ -88,7 +88,7 @@ bfs_dist <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- bfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- bfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, dist = TRUE)$dist
   as.integer(ind)
 }
@@ -102,7 +102,7 @@ dfs_rank <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- dfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- dfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE)$order
   match(seq_along(ind), as.integer(ind))
 }
@@ -113,7 +113,7 @@ dfs_rank_out <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- dfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- dfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, order.out = TRUE)$order.out
   match(seq_along(ind), as.integer(ind))
 }
@@ -124,7 +124,7 @@ dfs_parent <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- dfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- dfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, father = TRUE)$father
   as.integer(ind)
 }
@@ -135,7 +135,7 @@ dfs_dist <- function(root, mode = 'out', unreachable = FALSE) {
   expect_nodes()
   graph <- .G()
   root <- as_ind(root, gorder(graph))
-  ind <- dfs(graph = graph, root = root, neimode = mode, unreachable = unreachable,
+  ind <- dfs(graph = graph, root = root, mode = mode, unreachable = unreachable,
              order = TRUE, dist = TRUE)$dist
   as.integer(ind)
 }


### PR DESCRIPTION
"The neimode argument of bfs() and dfs() was renamed to mode for sake of consistency with other functions. The old argument name is deprecated and will be removed in 1.4.0." - from https://github.com/igraph/rigraph/blob/dev/inst/NEWS.md
change made in issue: https://github.com/igraph/rigraph/issues/495