### PR TITLE
Use `pull(1)` instead of `first()`

### DIFF
--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -8,7 +8,7 @@ get_number_of_groups <- function(graph, group_clustering_function) {
   graph %>%
     mutate(groups = group_clustering_function) %>%
     dplyr::as_tibble(what = 'vertices') %>%
-    distinct() %>% dplyr::count() %>% dplyr::first()
+    distinct() %>% dplyr::count() %>% dplyr::pull(1)
 }
 
 test_that("grouping returns integer vector", {


### PR DESCRIPTION
Following https://github.com/tidyverse/dplyr/pull/6331, `first()` and `last()` select rowwise instead of colwise. This PR fixes this by using `pull()` instead.

We plan to release on January 27. A pre-emptive compat release would be helpful if possible. Thanks!