### PR TITLE
State implicit igraph version requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Roxygen: list(markdown = TRUE)
 Imports: 
     tibble,
     dplyr (>= 0.8.5),
-    igraph,
+    igraph (>= 1.3.0),
     magrittr,
     utils,
     rlang,


### PR DESCRIPTION
`mode=` argument to `bfs()`/`dfs()` was only added in 1.3.0:

https://github.com/igraph/rigraph/blob/ebd30ec0a7b8553e662eb0eff21c4b3c62fb01bf/inst/NEWS.md?plain=1#L229-L231

But is used extensively in `tidygraph`, e.g.

https://github.com/thomasp85/tidygraph/blob/abc8cc12eb1bbc5bec302b80589ad027d85a70db/R/search.R#L80-L81