### PR TITLE
Establish compatibility with igraph >= 2.0.0

### DIFF
--- a/R/random_walk.R
+++ b/R/random_walk.R
@@ -50,7 +50,7 @@ random_walk_rank <- function(n, root = NULL, mode = "out", weights = NULL) {
     if (!quo_is_null(weights)) {
       cli::cli_warn('{.arg weights} is ignored when doing a random walk on nodes')
     }
-    walk <- as.integer(random_walk(graph, root, n, mode))
+    walk <- as.integer(random_walk(graph, root, n, mode = mode))
     len_out <- gorder(graph)
   } else {
     weights <- eval_tidy(weights, .E(focused = FALSE)) %||% NA


### PR DESCRIPTION
@thomasp85: This is a change that slipped through, apologies for the short notice.

igraph might start adding ellipsis arguments to enforce naming of "unusual" arguments after the third argument or so, but only after the 2.0.0 release. For now, this seems to be the only problem.

We're planning to send igraph to CRAN on January 23.

Tracking issue: https://github.com/igraph/rigraph/issues/989.