### PR TITLE
add test case for bind_graph on lists + implement fix

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -46,12 +46,12 @@
 #' graph %>% bind_graphs(new_graph)
 #'
 bind_graphs <- function(.data, ...) {
-  .data <- unfocus(.data)
   if (is_bare_list(.data)) {
-    .data <- lapply(c(.data, list2(...)), as_tbl_graph)
+    .data <- lapply(lapply(c(.data, list2(...)), unfocus), as_tbl_graph)
     dots <- .data[-1]
     .data <- .data[[1]]
   } else {
+    .data <- unfocus(.data)
     .data <- as_tbl_graph(.data)
     dots <- lapply(list2(...), as_tbl_graph)
   }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -10,6 +10,15 @@ test_that("bind_graphs works", {
   tbl <- as_tibble(gr)
   expect_true(all(lengths(lapply(split(tbl$group, tbl$comp), unique)) == 1))
 })
+
+test_that("bind_graphs works for .data a list of supported objects", {
+  gr1 <- create_notable('bull')
+  gr2 <- gr1
+  gr1 <- mutate(gr1, group = 1)
+  gr2 <- mutate(gr2, group = 2)
+  gr <- expect_no_error(bind_graphs(list(gr1, gr2)))
+})
+
 test_that('bind_nodes works', {
   gr1 <- tbl_graph(head(mtcars))
   gr1 <- bind_nodes(gr1, tail(mtcars))


### PR DESCRIPTION
As documented, `bind_graph` indicates it supports passing a list of objects as .data.

However, the current implementation does not support that use case.

This code introduces a test (which the current main code fails) + a fix to provide the documented behavior of bind_graph (which is definitely worth having, and the extant code suggests is actually contemplated).

Alternatives considered: an unfocus.list method. That seems potentially reasonable, and perhaps useful for other areas of the code I didn't examine, but would also require some careful checking of method dispatch. I went with this approach as more surgical.